### PR TITLE
feat: 반응형 웹 위한 desktop & mobile css

### DIFF
--- a/apps/ceos/src/components/Title/index.tsx
+++ b/apps/ceos/src/components/Title/index.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text, desktop, mobile } from '@ceos-fe/ui';
+import { Desktop, Flex, Mobile, Text } from '@ceos-fe/ui';
 export const Title = ({
   title,
   explain,
@@ -14,6 +14,7 @@ export const Title = ({
       webString += ex;
     }
   });
+
   return (
     <Flex direction="column" margin="80px 0" webGap={12} mobileGap={10}>
       <Text
@@ -23,14 +24,18 @@ export const Title = ({
       >
         {title}
       </Text>
-      <Flex direction="row" css={desktop}>
-        <Text webTypo="Body1">{webString}</Text>
-      </Flex>
-      <Flex direction="column" css={mobile}>
-        {explain.map((ex) => {
-          return <Text mobileTypo="Body1">{ex}</Text>;
-        })}
-      </Flex>
+      <Desktop>
+        <Flex direction="row">
+          <Text webTypo="Body1">{webString}</Text>
+        </Flex>
+      </Desktop>
+      <Mobile>
+        <Flex direction="column">
+          {explain.map((ex) => {
+            return <Text mobileTypo="Body1">{ex}</Text>;
+          })}
+        </Flex>
+      </Mobile>
     </Flex>
   );
 };

--- a/apps/ceos/src/components/Title/index.tsx
+++ b/apps/ceos/src/components/Title/index.tsx
@@ -1,0 +1,36 @@
+import { Flex, Text, desktop, mobile } from '@ceos-fe/ui';
+export const Title = ({
+  title,
+  explain,
+}: {
+  title: string;
+  explain: string[];
+}) => {
+  let webString = '';
+  explain.forEach((ex, idx) => {
+    if (idx >= 1) {
+      webString += ` ${ex}`;
+    } else {
+      webString += ex;
+    }
+  });
+  return (
+    <Flex direction="column" margin="80px 0" webGap={12} mobileGap={10}>
+      <Text
+        webTypo="Heading1_Eng"
+        mobileTypo="Heading1_Eng"
+        paletteColor="Blue"
+      >
+        {title}
+      </Text>
+      <Flex direction="row" css={desktop}>
+        <Text webTypo="Body1">{webString}</Text>
+      </Flex>
+      <Flex direction="column" css={mobile}>
+        {explain.map((ex) => {
+          return <Text mobileTypo="Body1">{ex}</Text>;
+        })}
+      </Flex>
+    </Flex>
+  );
+};

--- a/apps/ceos/src/pages/FAQ/index.tsx
+++ b/apps/ceos/src/pages/FAQ/index.tsx
@@ -1,7 +1,15 @@
 import { Flex } from '@ceos-fe/ui';
+import { Title } from '@ceos/components/Title';
 
 const FAQ = () => {
-  return <Flex direction="row">FAQ 페이지</Flex>;
+  return (
+    <Flex direction="column">
+      <Title
+        title="FAQ"
+        explain={['ceos에 대해 자주 묻는 질문들에', '대한 답변입니다.']}
+      />
+    </Flex>
+  );
 };
 
 export default FAQ;

--- a/apps/ceos/src/pages/activity/index.tsx
+++ b/apps/ceos/src/pages/activity/index.tsx
@@ -1,7 +1,18 @@
 import { Flex } from '@ceos-fe/ui';
+import { Title } from '@ceos/components/Title';
 
 const Activity = () => {
-  return <Flex direction="row">Activity 페이지</Flex>;
+  return (
+    <Flex direction="column">
+      <Title
+        title="Activity"
+        explain={[
+          'ceos에서는 it 창업과 관련된',
+          '다양한 활동을 진행하고 있습니다.',
+        ]}
+      />
+    </Flex>
+  );
 };
 
 export default Activity;

--- a/apps/ceos/src/pages/project/index.tsx
+++ b/apps/ceos/src/pages/project/index.tsx
@@ -1,7 +1,18 @@
 import { Flex } from '@ceos-fe/ui';
+import { Title } from '@ceos/components/Title';
 
 const Project = () => {
-  return <Flex direction="row">Project 페이지</Flex>;
+  return (
+    <Flex direction="column">
+      <Title
+        title="Project"
+        explain={[
+          '신촌 연합 IT 창업동아리 CEOS의',
+          '활동 프로젝트를 소개합니다.',
+        ]}
+      />
+    </Flex>
+  );
 };
 
 export default Project;

--- a/apps/ceos/src/pages/recruit/index.tsx
+++ b/apps/ceos/src/pages/recruit/index.tsx
@@ -1,7 +1,12 @@
 import { Flex } from '@ceos-fe/ui';
+import { Title } from '@ceos/components/Title';
 
 const Recruit = () => {
-  return <Flex direction="row">Recruit 페이지</Flex>;
+  return (
+    <Flex direction="column">
+      <Title title="Recruit" explain={['']}></Title>
+    </Flex>
+  );
 };
 
 export default Recruit;

--- a/packages/ui/src/styles/index.tsx
+++ b/packages/ui/src/styles/index.tsx
@@ -5,3 +5,4 @@ export * from './typo';
 export * from './glass';
 
 export * from './GlobalStyles';
+export * from './mediaQuery';

--- a/packages/ui/src/styles/mediaQuery.ts
+++ b/packages/ui/src/styles/mediaQuery.ts
@@ -1,13 +1,15 @@
-import { css } from '@emotion/react';
+import styled from '@emotion/styled';
 
-export const desktop = css`
+export const Desktop = styled.div`
+  display: flex;
   @media (max-width: 1023px) {
     display: none;
   }
 `;
 
-export const mobile = css`
-  @media (min-width: 1024px) {
-    display: none;
+export const Mobile = styled.div`
+  display: none;
+  @media (max-width: 1023px) {
+    display: flex;
   }
 `;

--- a/packages/ui/src/styles/mediaQuery.ts
+++ b/packages/ui/src/styles/mediaQuery.ts
@@ -1,0 +1,13 @@
+import { css } from '@emotion/react';
+
+export const desktop = css`
+  @media (max-width: 1023px) {
+    display: none;
+  }
+`;
+
+export const mobile = css`
+  @media (min-width: 1024px) {
+    display: none;
+  }
+`;


### PR DESCRIPTION
## 🛠 관련 이슈
#3

## 📝 수정 사항

ceos에서 반응형웹 제작을 위한 css 처리가 필요해서 desktop, mobile css를 추가하고
이를 적용한 Title을 샘플로 만들어봤습니다. 

- desktop
<img width="1186" alt="image" src="https://github.com/CEOS-Developers/CEOS-FE/assets/65931227/2f0d67af-e4b5-430c-995a-f4f7af27a12d">

- mobile 
<img width="648" alt="image" src="https://github.com/CEOS-Developers/CEOS-FE/assets/65931227/238a453f-e856-4662-a7db-000cd1103bb4">


