### PR TITLE
refactor: TextField에 Right 추가

### DIFF
--- a/apps/ceos/src/pages/index.tsx
+++ b/apps/ceos/src/pages/index.tsx
@@ -1,34 +1,10 @@
-import { Flex } from '@ceos-fe/ui';
-import { SelectButton } from '../../../../packages/ui/src/components/SelectButton/index';
-import { useForm } from 'react-hook-form';
+import { Flex, TextField } from '@ceos-fe/ui';
+import { Instagram } from '../../../../packages/ui/src/assets/FloatingButton/Instagram';
+
 export default function Home() {
-  const { register, watch } = useForm({
-    defaultValues: {
-      title: '',
-      content: '',
-      part: '',
-    },
-  });
   return (
     <Flex direction="row">
-      <SelectButton
-        variant="admin"
-        value="기획"
-        webWidth={240}
-        {...register('part')}
-      />
-      <SelectButton
-        variant="admin"
-        value="디자인"
-        webWidth={240}
-        {...register('part')}
-      />
-      <SelectButton
-        variant="admin"
-        value="개발"
-        webWidth={240}
-        {...register('part')}
-      />
+      <TextField right={<Instagram />} />
     </Flex>
   );
 }

--- a/packages/ui/src/components/TextField/index.tsx
+++ b/packages/ui/src/components/TextField/index.tsx
@@ -153,6 +153,10 @@ const StyledIcon = styled.div`
   top: 50%;
   right: 16px;
   transform: translate(0, -50%);
+
+  @media (max-width: 1023px) {
+    right: 12px;
+  }
 `;
 const StyledTextArea = styled.textarea<{
   isAdmin: boolean;

--- a/packages/ui/src/components/TextField/index.tsx
+++ b/packages/ui/src/components/TextField/index.tsx
@@ -1,5 +1,10 @@
 import styled from '@emotion/styled';
-import { ForwardedRef, InputHTMLAttributes, forwardRef } from 'react';
+import {
+  ForwardedRef,
+  InputHTMLAttributes,
+  ReactNode,
+  forwardRef,
+} from 'react';
 import { theme } from '../../styles';
 import { SubTextFieldIcon } from '../../assets/SubTextFieldIcon';
 import { Flex } from '../common';
@@ -14,6 +19,7 @@ interface TextFieldProps
   isAdmin?: boolean;
   isSubTextField?: boolean;
   fontColor?: string;
+  right?: ReactNode;
 }
 
 /**
@@ -25,6 +31,7 @@ interface TextFieldProps
  * @param {boolean} isAdmin: 어드민용 TextField 여부
  * @param {boolean} isSubTextField: 하위 TextField 여부
  * @param {boolean} fontColor: TextField 내부 폰트 색상
+ * @param {ReactNode} right: 우측 아이콘
  */
 export const TextField = forwardRef<
   HTMLInputElement | HTMLTextAreaElement,
@@ -41,6 +48,7 @@ export const TextField = forwardRef<
       isAdmin = false,
       isSubTextField = false,
       fontColor = theme.palette.Black,
+      right,
       ...props
     },
     ref,
@@ -61,14 +69,17 @@ export const TextField = forwardRef<
               fontColor={fontColor}
             />
           ) : (
-            <StyledInput
-              {...props}
-              ref={ref as ForwardedRef<HTMLInputElement>}
-              placeholder={placeholder}
-              spellCheck={false}
-              isAdmin={isAdmin}
-              fontColor={fontColor}
-            />
+            <InputContainer>
+              <StyledInput
+                {...props}
+                ref={ref as ForwardedRef<HTMLInputElement>}
+                placeholder={placeholder}
+                spellCheck={false}
+                isAdmin={isAdmin}
+                fontColor={fontColor}
+              />
+              {right && <StyledIcon>{right}</StyledIcon>}
+            </InputContainer>
           )}
         </Flex>
         {helperText && (
@@ -105,6 +116,10 @@ const StyledHelperTextBox = styled.div`
     margin-top: 14px;
   }
 `;
+const InputContainer = styled.div`
+  position: relative;
+  width: 100%;
+`;
 const StyledInput = styled.input<{ isAdmin: boolean; fontColor: string }>`
   width: 100%;
   padding: 8px 16px;
@@ -132,6 +147,12 @@ const StyledInput = styled.input<{ isAdmin: boolean; fontColor: string }>`
   @media (max-width: 1023px) {
     ${theme.typo.Mobile.Body1};
   }
+`;
+const StyledIcon = styled.div`
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  transform: translate(0, -50%);
 `;
 const StyledTextArea = styled.textarea<{
   isAdmin: boolean;

--- a/packages/ui/src/components/TextField/index.tsx
+++ b/packages/ui/src/components/TextField/index.tsx
@@ -77,6 +77,7 @@ export const TextField = forwardRef<
                 spellCheck={false}
                 isAdmin={isAdmin}
                 fontColor={fontColor}
+                isRight={Boolean(right)}
               />
               {right && <StyledIcon>{right}</StyledIcon>}
             </InputContainer>
@@ -120,9 +121,13 @@ const InputContainer = styled.div`
   position: relative;
   width: 100%;
 `;
-const StyledInput = styled.input<{ isAdmin: boolean; fontColor: string }>`
+const StyledInput = styled.input<{
+  isAdmin: boolean;
+  fontColor: string;
+  isRight: boolean;
+}>`
   width: 100%;
-  padding: 8px 16px;
+  padding: ${({ isRight }) => (isRight ? '8px 50px 8px 16px' : '8px 16px')};
 
   box-sizing: border-box;
 


### PR DESCRIPTION
## 🛠 관련 이슈
- closes #39 

## 📝 수정 사항
- right field 추가
```tsx
<TextField right={<Instagram />} />
```
- 위와 같이 선언해주시면 아래 처럼 사용 가능합니다.
<img width="376" alt="스크린샷 2023-06-24 10 09 59" src="https://github.com/CEOS-Developers/CEOS-FE/assets/76840145/a011427a-1fe3-4eca-b59e-a6155cc1b11e">
