### PR TITLE
feat: layout 사이드 여백

### DIFF
--- a/apps/ceos/src/components/Layout/index.tsx
+++ b/apps/ceos/src/components/Layout/index.tsx
@@ -14,7 +14,6 @@ export const Layout = ({ children }: { children: React.ReactNode }) => {
 };
 
 const CustomFlex = styled(Flex)`
-  width: 856px;
   @media (max-width: 1023px) {
     width: 346px;
   }

--- a/apps/ceos/src/components/Layout/index.tsx
+++ b/apps/ceos/src/components/Layout/index.tsx
@@ -1,13 +1,21 @@
 import { Header } from '@ceos/components/Header';
 import { Flex } from '@ceos-fe/ui';
+import styled from '@emotion/styled';
 
 export const Layout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <>
+    <Flex direction="column" align="center">
       <Header backColor="White" />
-      <Flex direction="column" className="header-padding">
+      <CustomFlex direction="column" className="header-padding">
         {children}
-      </Flex>
-    </>
+      </CustomFlex>
+    </Flex>
   );
 };
+
+const CustomFlex = styled(Flex)`
+  width: 856px;
+  @media (max-width: 1023px) {
+    width: 346px;
+  }
+`;

--- a/apps/ceos/src/pages/recruit/apply/index.tsx
+++ b/apps/ceos/src/pages/recruit/apply/index.tsx
@@ -1,0 +1,21 @@
+import { Flex, TextField, Text } from '@ceos-fe/ui';
+import { Title } from '@ceos/components/Title';
+
+const Apply = () => {
+  return (
+    <Flex direction="column">
+      <Title
+        title="CEOS 18기 리크루팅"
+        explain={['서류 답변은 한 번만 가능하니,', '꼼꼼하게 확인 바랍니다:)']}
+      ></Title>
+      <Flex direction="row" justify="space-between">
+        <Flex direction="column" align="start" webGap={8}>
+          <Text webTypo="Label3">이름</Text>
+          <TextField />
+        </Flex>
+      </Flex>
+    </Flex>
+  );
+};
+
+export default Apply;

--- a/apps/ceos/src/pages/recruit/apply/index.tsx
+++ b/apps/ceos/src/pages/recruit/apply/index.tsx
@@ -1,17 +1,41 @@
 import { Flex, TextField, Text } from '@ceos-fe/ui';
 import { Title } from '@ceos/components/Title';
+import { SelectButton } from '../../../../../../packages/ui/src/components/SelectButton/index';
+import { useForm } from 'react-hook-form';
 
 const Apply = () => {
+  const { register, watch } = useForm({
+    defaultValues: {
+      gender: '',
+    },
+  });
   return (
     <Flex direction="column">
       <Title
         title="CEOS 18기 리크루팅"
         explain={['서류 답변은 한 번만 가능하니,', '꼼꼼하게 확인 바랍니다:)']}
       ></Title>
-      <Flex direction="row" justify="space-between">
+      <Flex direction="row" justify="space-between" width={680}>
         <Flex direction="column" align="start" webGap={8}>
           <Text webTypo="Label3">이름</Text>
-          <TextField />
+          <TextField width={328} />
+        </Flex>
+        <Flex direction="column" align="start" webGap={8}>
+          <Text webTypo="Label3">성별</Text>
+          <Flex webGap={12}>
+            <SelectButton
+              variant="ceos"
+              value="남성"
+              webWidth={158}
+              {...register('gender')}
+            />
+            <SelectButton
+              variant="ceos"
+              value="여성"
+              webWidth={158}
+              {...register('gender')}
+            />
+          </Flex>
         </Flex>
       </Flex>
     </Flex>


### PR DESCRIPTION
## 🛠 관련 이슈
#30 

## 📝 수정 사항
ceos layout 양 옆에 여백을 추가했습니다!!

- 수정 후 - PC
<img width="1103" alt="image" src="https://github.com/CEOS-Developers/CEOS-FE/assets/65931227/46fbe881-877b-4059-ba15-4475446ff3ca">

- 수정 후 - mobile ; 컴포넌트 사이즈 깨짐은 양해바람니다..
<img width="499" alt="image" src="https://github.com/CEOS-Developers/CEOS-FE/assets/65931227/a3b73dc9-8a5e-4fcf-857a-ad57ab191499">



