### PR TITLE
feat: ADMIN - Alert 추가

### DIFF
--- a/apps/admin/src/components/Alert/index.tsx
+++ b/apps/admin/src/components/Alert/index.tsx
@@ -1,0 +1,26 @@
+import { Alert as AntdAlert } from 'antd';
+import styled from '@emotion/styled';
+
+interface AlertProps {
+  type: 'success' | 'error';
+  message: string;
+}
+
+/**
+ * @param {'success' | 'error'} type: alert type
+ * @param {string} message: alert message
+ */
+export const Alert = ({ message, type }: AlertProps) => {
+  return (
+    <Container>
+      <AntdAlert message={message} type={type} showIcon />
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  position: fixed;
+  bottom: 60px;
+  left: 50%;
+  transform: translate(-50%, 0);
+`;

--- a/apps/admin/src/hooks/useAlert.tsx
+++ b/apps/admin/src/hooks/useAlert.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+export type AlertType = 'success' | 'error';
+
+export const useAlert = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [type, setType] = useState<AlertType>('success');
+
+  useEffect(() => {
+    const timer = setTimeout(() => setIsOpen(false), 5000);
+
+    return () => clearTimeout(timer);
+  }, [isOpen]);
+
+  const openAlert = (type: AlertType) => {
+    setType(type);
+    setIsOpen(true);
+  };
+
+  return { isOpen, type, openAlert };
+};

--- a/apps/admin/src/pages/application/index.tsx
+++ b/apps/admin/src/pages/application/index.tsx
@@ -28,6 +28,8 @@ import {
   useQuery,
 } from '@tanstack/react-query';
 import { getFormattedDate } from '@admin/utils/date';
+import { useAlert } from '@admin/hooks/useAlert';
+import { Alert } from '@admin/components/Alert';
 
 interface ApplicationFormInterface {
   commonQuestions: AdminApplicationListItemInterface[];
@@ -50,8 +52,15 @@ export default function Application() {
     AdminApplicationInterface,
     AxiosError
   >(['admin', 'application'], adminApplicationApi.GET_APPLICATION);
+
+  const { isOpen, type, openAlert } = useAlert();
+
   const { mutate: putApplication } = useMutation(
     adminApplicationApi.PUT_APPLICATION,
+    {
+      onSuccess: () => openAlert('success'),
+      onError: () => openAlert('error'),
+    },
   );
 
   const [allPartQuestions, setAllPartQuestions] = useState<
@@ -559,6 +568,15 @@ export default function Application() {
           저장하기
         </Button>
       </Flex>
+
+      {isOpen && (
+        <Alert
+          type={type}
+          message={
+            type === 'success' ? '요청에 성공했습니다' : '요청에 실패했습니다'
+          }
+        />
+      )}
     </>
   );
 }

--- a/apps/admin/src/pages/faq/index.tsx
+++ b/apps/admin/src/pages/faq/index.tsx
@@ -14,6 +14,8 @@ import { useFieldArray, useForm } from 'react-hook-form';
 import { useEffect } from 'react';
 import { Plus } from '@admin/assets/Plus';
 import { AxiosError } from 'axios';
+import { useAlert } from '../../hooks/useAlert';
+import { Alert } from '@admin/components/Alert';
 
 type FaqCategoryKorType =
   | '리크루팅 관련 질문'
@@ -46,6 +48,8 @@ export default function Faq() {
     name: 'faqList',
   });
 
+  const { isOpen, type, openAlert } = useAlert();
+
   const { data, isFetching, isSuccess } = useQuery<FaqResponse, AxiosError>(
     ['admin', 'faq', watch('category')],
     () => adminFaqApi.GET_FAQ(CATEGORY_MAP[watch('category')]),
@@ -54,17 +58,26 @@ export default function Faq() {
     FaqListItemInterface,
     AxiosError,
     FaqListItemInterface
-  >(adminFaqApi.POST_FAQ);
+  >(adminFaqApi.POST_FAQ, {
+    onSuccess: () => openAlert('success'),
+    onError: () => openAlert('error'),
+  });
   const { mutate: patchFaqMutation } = useMutation<
     FaqListItemInterface,
     AxiosError,
     FaqListItemInterface
-  >(adminFaqApi.PATCH_FAQ);
+  >(adminFaqApi.PATCH_FAQ, {
+    onSuccess: () => openAlert('success'),
+    onError: () => openAlert('error'),
+  });
   const { mutate: deleteFaqMutation } = useMutation<
     FaqListItemInterface,
     AxiosError,
     FaqListItemInterface
-  >(adminFaqApi.DELETE_FAQ);
+  >(adminFaqApi.DELETE_FAQ, {
+    onSuccess: () => openAlert('success'),
+    onError: () => openAlert('error'),
+  });
 
   useEffect(() => {
     if (!isFetching && isSuccess) {
@@ -183,6 +196,14 @@ export default function Faq() {
           </Flex>
         </Button>
       </Flex>
+      {isOpen && (
+        <Alert
+          type={type}
+          message={
+            type === 'success' ? '요청에 성공했습니다' : '요청에 실패했습니다'
+          }
+        />
+      )}
     </>
   );
 }

--- a/apps/admin/src/pages/recruit/index.tsx
+++ b/apps/admin/src/pages/recruit/index.tsx
@@ -14,6 +14,8 @@ import {
   useMutation,
   useQuery,
 } from '@tanstack/react-query';
+import { useAlert } from '@admin/hooks/useAlert';
+import { Alert } from '@admin/components/Alert';
 
 interface RecruitDateInterface extends RecruitBaseInterface {
   startDateDoc: Date;
@@ -31,8 +33,15 @@ export default function Recruit() {
     ['admin', 'recruit'],
     async () => await adminRecruitApi.GET_RECRUIT(),
   );
+
+  const { isOpen, type, openAlert } = useAlert();
+
   const { mutate: postRecruitments } = useMutation(
     adminRecruitApi.POST_RECRUIT,
+    {
+      onSuccess: () => openAlert('success'),
+      onError: () => openAlert('error'),
+    },
   );
 
   const { getValues, setValue, reset, register } =
@@ -246,6 +255,15 @@ export default function Recruit() {
       >
         저장하기
       </Button>
+
+      {isOpen && (
+        <Alert
+          type={type}
+          message={
+            type === 'success' ? '요청에 성공했습니다' : '요청에 실패했습니다'
+          }
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
## 🛠 관련 이슈
없음

## 📝 수정 사항
- Alert 컴포넌트와 hook을 만들었습니다.
```tsx
const { isOpen, type, openAlert } = useAlert();

const { mutate: putApplication } = useMutation(
  adminApplicationApi.PUT_APPLICATION,
  {
    onSuccess: () => openAlert('success'),
    onError: () => openAlert('error'),
  },
);
```
- 이런식으로 hook을 선언하고 onSuccess와 onError 시에 type을 넘겨서 alert를 open시켜주면 됩니다.
```tsx
      {isOpen && (
        <Alert
          type={type}
          message={
            type === 'success' ? '요청에 성공했습니다' : '요청에 실패했습니다'
          }
        />
      )}
```
- 그리고 컴포넌트 끝쯤에 이런 식으로 Alert 컴포넌트도 넣어주면 끄읕,,,

![화면 기록 2023-07-23 23 39 59](https://github.com/CEOS-Developers/CEOS-FE/assets/76840145/32e1adbd-11e5-4368-92d3-116273a4e1eb)
