### PR TITLE
fix : 모바일 activityCard 깨짐

### DIFF
--- a/apps/ceos/src/pages/activity/index.tsx
+++ b/apps/ceos/src/pages/activity/index.tsx
@@ -60,7 +60,13 @@ const Activity = () => {
             <GridContainer>
               {activityList &&
                 activityList.map((activity, idx) => (
-                  <ActivityCard key={idx} activityCard={activity} />
+                  <ActivityCard
+                    key={idx}
+                    id={activity.id}
+                    name={activity.name}
+                    imageUrl={activity.imageUrl}
+                    content={activity.content}
+                  />
                 ))}
             </GridContainer>
           </Flex>
@@ -78,10 +84,21 @@ const Activity = () => {
             ]}
           />
           <TopMargin />
-          <Flex direction="column" mobileGap={20} margin="0 0 36px 0">
+          <Flex
+            direction="column"
+            mobileGap={20}
+            margin="0 0 36px 0"
+            padding="0 30px"
+          >
             {activityList?.map((activity, idx) => {
               return (
-                <ActivityCard key={`activity_${idx}`} activityCard={activity} />
+                <ActivityCard
+                  key={`activity_${idx}`}
+                  id={activity.id}
+                  name={activity.name}
+                  imageUrl={activity.imageUrl}
+                  content={activity.content}
+                />
               );
             })}
           </Flex>

--- a/packages/ui/src/components/Card/ActivityCard.tsx
+++ b/packages/ui/src/components/Card/ActivityCard.tsx
@@ -15,12 +15,15 @@ export interface AdminActivityCardProps extends ActivityCardProps {
   onClickUpdate: () => void;
 }
 
-export const ActivityCard = (props: {
-  activityCard: ActivityCardProps;
-}): EmotionJSX.Element => {
-  const { imageUrl, name, content } = props.activityCard;
+export const ActivityCard = ({
+  id,
+  name,
+  imageUrl,
+  content,
+  ...props
+}: ActivityCardProps) => {
   return (
-    <Flex direction="column" width="auto" height="auto">
+    <Flex direction="column" height="auto" padding="">
       <ActivityImg src={imageUrl} width={328} height={184} />
 
       <Content>
@@ -75,9 +78,8 @@ const ActivityImg = styled.img`
   object-fit: cover;
   background-color: ${theme.palette.Gray5};
 
-  @media (max-width: 1023px) {
-    width: 346px;
-    height: 194px;
+  @media (max-width: 768px) {
+    width: 100%;
   }
 `;
 
@@ -93,7 +95,7 @@ const Content = styled.div`
 
   background-color: ${theme.palette.Gray1};
 
-  @media (max-width: 1023px) {
+  @media (max-width: 768px) {
     width: 100%;
   }
 `;


### PR DESCRIPTION
## 🛠 관련 이슈
#76 
## 📝 수정 사항
- 기존 activity 카드 모바일 버전 width가 고정 픽셀로 박혀있던 것을 100%로 수정하였습니다.
- 태블릿 화면에서는 100% 할 시 안 예뻐서... 768px 이하만 100%가 반영되도록 했습니다.

<img width="576" alt="image" src="https://github.com/CEOS-Developers/CEOS-FE/assets/65931227/83121cd6-aee7-43ef-8e58-4b4aa86666e7">

