### PR TITLE
Fix: 프로젝트 모달 height auto

### DIFF
--- a/apps/ceos/src/components/project/DetailModal/index.tsx
+++ b/apps/ceos/src/components/project/DetailModal/index.tsx
@@ -285,7 +285,7 @@ const Container = styled.div`
 const DetailThumbnailImageContainer = styled.div`
   width: 100%;
   max-width: 1032px;
-  height: 541px;
+  height: auto;
   position: relative;
   border-radius: 20px;
   aspect-ratio: 1032 / 541;


### PR DESCRIPTION
## 🛠 관련 이슈
## 📝 수정 사항
프로젝트 모달 내 이미지 컨테이너가 고정 px로 들어가 있어 이미지 크기에 따라 다른 요소들을 가리는 이슈가 있어 이를 해결하였습니다.
