### PR TITLE
fix: 모바일 뷰에서 month 에러 수정

### DIFF
--- a/apps/ceos/src/components/recruit/Schedule.tsx
+++ b/apps/ceos/src/components/recruit/Schedule.tsx
@@ -135,7 +135,9 @@ const Schedule = ({
 
           {questionList?.times.map((time, timeIdx) => {
             const questionDate = new Date(time.date);
-            const questionMonthDay = `${questionDate.getMonth()}/${questionDate.getDate()}`;
+            const questionMonthDay = `${
+              questionDate.getMonth() + 1
+            }/${questionDate.getDate()}`;
             const questionDay = dateToDay[questionDate.getDay() as number];
 
             return (


### PR DESCRIPTION
## 🛠 관련 이슈
mobile view에서 면접 일자 month가 제대로 반영되지 않는 이슈해결
## 📝 수정 사항
