### PR TITLE
fix: 서버 재배포로 토큰 만료시 로그아웃 처리

### DIFF
--- a/apps/admin/src/components/Layout/index.tsx
+++ b/apps/admin/src/components/Layout/index.tsx
@@ -18,7 +18,9 @@ export const Layout = ({ children }: { children: React.ReactNode }) => {
   const [loading, setLoading] = useState<boolean>(true);
 
   const [accessToken, setAccessToken] = useRecoilState(accessTokenState);
-  const [appCookies, setAppCookies] = useCookies(['LOGIN_EXPIRES']);
+  const [appCookies, setAppCookies, removeAppCookies] = useCookies([
+    'LOGIN_EXPIRES',
+  ]);
 
   const { mutate: getNewAccessToken } = useMutation(
     () => adminAuthApi.POST_REFRESHTOKEN(cookies),
@@ -32,6 +34,15 @@ export const Layout = ({ children }: { children: React.ReactNode }) => {
         ] = `Bearer ${data.data.accessToken}`;
         if (data.data.refreshToken !== undefined)
           LoginUntilExpires(data.data.refreshToken);
+      },
+      onError: (err: any) => {
+        // 일단 404에 대해서만 로그아웃 처리
+        if (err.response.status === 404) {
+          setLogin(false);
+          setLoading(false);
+          setAccessToken('');
+          removeAppCookies('LOGIN_EXPIRES', { path: '/' });
+        }
       },
     },
   );


### PR DESCRIPTION
## 🛠 관련 이슈
x
## 📝 수정 사항
로직 중복 호출이 많아서 일단은
404(백엔드에서 서버 재배포시 redis 초기화로 인한 token 정보 재설정)코드에 대해서만 로그아웃 처리되도록 해놓음