### PR TITLE
Feat(ceos): 고문 선택 및 표시 기능 추가

### DIFF
--- a/apps/admin/src/pages/management/add/[[...id]].tsx
+++ b/apps/admin/src/pages/management/add/[[...id]].tsx
@@ -281,6 +281,10 @@ export default function AddManagement() {
                     value: 'coChairman',
                   },
                   {
+                    label: '고문',
+                    value: 'advisor',
+                  },
+                  {
                     label: '개발',
                     value: 'develop',
                   },
@@ -316,6 +320,10 @@ export default function AddManagement() {
                   {
                     label: '멘토',
                     value: 'mentor',
+                  },
+                  {
+                    label: '고문',
+                    value: 'advisor',
                   },
                 ]}
                 label="role"

--- a/apps/ceos/src/pages/management/index.tsx
+++ b/apps/ceos/src/pages/management/index.tsx
@@ -110,6 +110,9 @@ const Management = () => {
           {managers?.generalAffairs.map((manager: ManagerInterface) => (
             <ManagementCard key={manager.id} managementCard={manager} />
           ))}
+          {managers?.advisors.map((manager: ManagerInterface) => (
+            <ManagementCard key={manager.id} managementCard={manager} />
+          ))}
           {managers?.partLeaders.map((manager: ManagerInterface) => (
             <ManagementCard key={manager.id} managementCard={manager} />
           ))}

--- a/packages/ui/src/components/Card/ManagementCard.tsx
+++ b/packages/ui/src/components/Card/ManagementCard.tsx
@@ -39,7 +39,10 @@ export const ManagementCard = (props: {
       )}
       <Content>
         <Text webTypo="Label3" mobileTypo="Label2" paletteColor="Gray5">
-          {part === '회장' || part === '부회장' || part === '공동회장'
+          {part === '회장' ||
+          part === '부회장' ||
+          part === '공동회장' ||
+          part === '고문'
             ? `${part}`
             : role === '총무'
             ? `${role} / ${part}`
@@ -99,7 +102,12 @@ export const MentorCard = (props: {
         <Wrapper className="extra-info">
           <Content className="extra-info">
             {company.split('\\n').map((item, idx) => (
-              <Text key={idx} webTypo="Body3" mobileTypo="Body1" paletteColor="White">
+              <Text
+                key={idx}
+                webTypo="Body3"
+                mobileTypo="Body1"
+                paletteColor="White"
+              >
                 {item}
               </Text>
             ))}


### PR DESCRIPTION
## 🛠 관련 이슈
- 고문 선택 및 CEOS 홈페이지에 표시하도록 구현했습니다.
## 📝 수정 사항
<img width="482" alt="image" src="https://github.com/user-attachments/assets/1911b548-508d-495a-b8ac-4c6e04100c16" />
<img width="727" alt="image" src="https://github.com/user-attachments/assets/a5fbd893-a931-40af-8635-982888064b21" />
