### PR TITLE
Fix(ceos): 파트 별 안내사항 및 면접 장소 공지 수정

### DIFF
--- a/apps/ceos/src/components/GlassBox/index.tsx
+++ b/apps/ceos/src/components/GlassBox/index.tsx
@@ -17,6 +17,7 @@ interface PassQueryType {
   query: PassDataInterface;
   setErrorText: Dispatch<string>;
 }
+
 const dateToDay: Record<number, string> = {
   0: '일',
   1: '월',
@@ -133,42 +134,14 @@ export const DocPassGlassBox = ({ query, setErrorText }: PassQueryType) => {
       ) : (
         <>
           <Text webTypo="Label1">[안내 사항]</Text>
-          <p>
-            - 인터뷰는 ZOOM을 통해 이루어집니다.
-            <br />
-            인터뷰 전 ZOOM이 가능한 계정이 있는지 확인해 주세요.
-          </p>
-          <p>
-            - 화상 면접이 가능한 노트북과
-            <br className="mobile" /> 이어폰을 준비해 주시고,
-            <br />
-            조용한 환경에서 면접에 참여해 주시길 부탁드리겠습니다.
-            <br />
-            면접 전에 미리 이어폰 및 마이크에 <br className="mobile" /> 문제가
-            없는지 확인 부탁드립니다
-          </p>
-          <p>
-            - 배정된 인터뷰 시간 15분 전에, <br />
-            하단 링크를 통해 오픈 채팅방에 접속해 주세요.
-            <br />
-            프로필 설정은 [이름(전화번호 뒷 4자리)]로
-            <br />
-            설정해 주시면 됩니다. (ex) 홍길동(4921)
-            <br />
-            시간이 되면 줌 링크를 오픈 채팅방에 공유드릴 예정입니다.
-          </p>
-          <p>- 인터뷰는 최대 4인 1조로 약 30분간 진행됩니다.</p>
+
+          {query.part === '기획' && <PRODUCT_INTERVIEW_NOTI />}
+          {query.part === '디자인' && <DESIGN_INTERVIEW_NOTI query={query} />}
+          {query.part === '프론트엔드' && <FRONTEND_INTERVIEW_NOTI />}
+          {query.part === '백엔드' && <BACKEND_INTERVIEW_NOTI />}
+
           <p>서류 합격을 다시 한번 축하드리며, 면접일에 뵙겠습니다 :)</p>
           <p>CEOS {query.generation}기 운영진 드림</p>
-          <Link
-            href={query.openChatUrl}
-            style={{ textDecoration: 'none', width: '218px' }}
-          >
-            <Button variant="white" webWidth={218}>
-              <ArrowUpRight color={theme.palette.Blue} />
-              &nbsp;오픈 채팅방 링크
-            </Button>
-          </Link>
         </>
       )}
       {isOpen && (
@@ -393,3 +366,92 @@ export const GlassBoxCss = ({ width = 552 }: { width?: number }) => css`
     }
   }
 `;
+
+const PRODUCT_INTERVIEW_NOTI = () => {
+  return (
+    <p>
+      - 기획 파트 인터뷰는 오프라인으로 진행됩니다.
+      <br />
+      - 가능한 면접 10분 전까지 장소에 도착해 주시길 바랍니다.
+      <br />
+      <br />
+      [기획 면접 장소]
+      <br />
+      3월 1일, 3월 2일 - 연세대학교 경영관 2층 209호 이글루
+    </p>
+  );
+};
+
+interface DesignNotiProps {
+  query: PassDataInterface;
+}
+const DESIGN_INTERVIEW_NOTI = ({ query }: DesignNotiProps) => {
+  return (
+    <p>
+      <p>
+        - 디자인 파트 인터뷰는 ZOOM을 통해 이루어집니다.
+        <br />
+        인터뷰 전 ZOOM이 가능한 계정이 있는지 확인해 주세요.
+      </p>
+      <p>
+        - 화상 면접이 가능한 노트북과
+        <br className="mobile" /> 이어폰을 준비해 주시고,
+        <br />
+        조용한 환경에서 면접에 참여해 주시길 부탁드리겠습니다.
+        <br />
+        면접 전에 미리 이어폰 및 마이크에 <br className="mobile" /> 문제가
+        없는지 확인 부탁드립니다
+      </p>
+      <p>
+        - 배정된 인터뷰 시간 15분 전에, <br />
+        하단 링크를 통해 오픈 채팅방에 접속해 주세요.
+        <br />
+        프로필 설정은 [이름(전화번호 뒷 4자리)]로
+        <br />
+        설정해 주시면 됩니다. (ex) 홍길동(4921)
+        <br />
+        시간이 되면 줌 링크를 오픈 채팅방에 공유드릴 예정입니다.
+      </p>
+      <p>- 인터뷰는 최대 4인 1조로 약 30분간 진행됩니다.</p>
+      <Link
+        href={query.openChatUrl}
+        style={{ textDecoration: 'none', width: '218px' }}
+      >
+        <Button variant="white" webWidth={218}>
+          <ArrowUpRight color={theme.palette.Blue} />
+          &nbsp;오픈 채팅방 링크
+        </Button>
+      </Link>
+    </p>
+  );
+};
+
+const FRONTEND_INTERVIEW_NOTI = () => {
+  return (
+    <p>
+      - 프론트엔드 파트 인터뷰는 오프라인으로 진행됩니다.
+      <br />
+      - 가능한 면접 10분 전까지 장소에 도착해 주시길 바랍니다.
+      <br />
+      <br />
+      [프론트엔드 면접 장소]
+      <br />
+      3월 2일 - 신촌 마커닷 스터디룸 (비밀번호 : 0403#)
+    </p>
+  );
+};
+
+const BACKEND_INTERVIEW_NOTI = () => {
+  return (
+    <p>
+      - 백엔드 파트 인터뷰는 오프라인으로 진행됩니다.
+      <br />
+      - 가능한 면접 10분 전까지 장소에 도착해 주시길 바랍니다.
+      <br />
+      <br />
+      [백엔드 면접 장소]
+      <br />
+      3월 1일, 3월 2일 - 홍대 카페나무 세미나실
+    </p>
+  );
+};

--- a/apps/ceos/src/components/Modals/checkModal.tsx
+++ b/apps/ceos/src/components/Modals/checkModal.tsx
@@ -58,6 +58,7 @@ export const CheckModal = forwardRef<HTMLDivElement, ModalProps>(
             pass: passCheck.data.pass,
             name: passCheck.data.name,
             date: passCheck.data.date,
+            part: passCheck.data.part,
             duration: passCheck.data.duration,
             otDate: passCheck.data.otDate,
             openChatUrl: passCheck.data.openChatUrl,

--- a/apps/ceos/src/components/recruit/interface.tsx
+++ b/apps/ceos/src/components/recruit/interface.tsx
@@ -50,6 +50,7 @@ export interface PassDataInterface {
   email: string;
   pass: string;
   name: string;
+  part?: string;
   attendanceStatus: boolean;
   date: string;
   otDate: string;

--- a/apps/ceos/src/pages/recruit/index.tsx
+++ b/apps/ceos/src/pages/recruit/index.tsx
@@ -41,6 +41,7 @@ const Recruit = () => {
     pass: '',
     name: '',
     attendanceStatus: false,
+    part: '',
     date: '',
     otDate: '',
     openChatUrl: '',


### PR DESCRIPTION
## 🛠 관련 이슈
파트 별 안내사항 및 면접장소공지 수정
++ passData, PassDataInterface에 'part' 데이터 추가
![Uploading 스크린샷 2025-02-28 오전 2.56.02.png…]()
<img width="514" alt="스크린샷 2025-02-28 오전 2 56 12" src="https://github.com/user-attachments/assets/3cb9c4ce-a930-46fb-aeec-854363a10376" />

## 📝 수정 사항
<img width="486" alt="스크린샷 2025-02-28 오전 2 39 54" src="https://github.com/user-attachments/assets/602211fe-4b8c-4d57-b38c-32e1cd14cef7" />
