### PR TITLE
Fix: Presigned URL 발급 API 요청 메서드 변경

### DIFF
--- a/apps/admin/src/hooks/usePresignedUrl.ts
+++ b/apps/admin/src/hooks/usePresignedUrl.ts
@@ -16,7 +16,7 @@ const usePresignedUrl = (apiType: ImageApiType) => {
   }, [image]);
 
   const getPresignedUrlMutation = useMutation(
-    imageApi[`GET_${apiType}_IMAGE`],
+    imageApi[`POST_${apiType}_IMAGE`],
     {
       onSuccess: async (data: string) => {
         uploadImageMutation.mutate({ url: data, file: image! });

--- a/packages/utils/src/apis/admin/imageApi.ts
+++ b/packages/utils/src/apis/admin/imageApi.ts
@@ -6,23 +6,23 @@ export interface uploadImageProps {
 }
 
 export const imageApi = {
-  GET_ACTIVITY_IMAGE: async (): Promise<string> => {
-    const response = await adminInstance.get(`/activities/image`);
+  POST_ACTIVITY_IMAGE: async (): Promise<string> => {
+    const response = await adminInstance.post(`/activities/image`);
 
     return response.data.data.url;
   },
-  GET_SPONSOR_IMAGE: async (): Promise<string> => {
-    const response = await adminInstance.get(`/sponsors/image`);
+  POST_SPONSOR_IMAGE: async (): Promise<string> => {
+    const response = await adminInstance.post(`/sponsors/image`);
 
     return response.data.data.url;
   },
-  GET_MANAGEMENT_IMAGE: async (): Promise<string> => {
-    const response = await adminInstance.get(`/managements/image`);
+  POST_MANAGEMENT_IMAGE: async (): Promise<string> => {
+    const response = await adminInstance.post(`/managements/image`);
 
     return response.data.data.url;
   },
-  GET_PROJECTS_IMAGE: async (): Promise<string> => {
-    const response = await adminInstance.get(`/projects/image`);
+  POST_PROJECTS_IMAGE: async (): Promise<string> => {
+    const response = await adminInstance.post(`/projects/image`);
 
     return response.data.data.url;
   },


### PR DESCRIPTION
## 🛠 관련 이슈

* 관련 이슈 없음

## 📝 수정 사항

- 백엔드에서 이미지 업로드용 Presigned URL 발급 API가 공개 조회 API 허용 정책에 따라 인증 없이 접근할 수 있는 문제를 개선했습니다.
- Presigned URL 발급 시 관리자 인증이 적용되도록 API 메서드를 `GET`에서 `POST`로 변경했으며, 프론트엔드에서도 변경된 API 명세에 맞춰 요청 메서드를 수정했습니다.

### 변경된 API

* `/projects/image`
* `/activities/image`
* `/sponsors/image`
* `/managements/image`

### 주요 변경 내용

* Presigned URL 발급 API 요청 메서드를 `GET`에서 `POST`로 변경
