### PR TITLE
Fix: 모집 지원 기간 시간 비교 로직 수정

### DIFF
--- a/apps/ceos/src/components/recruit/recruitSubHeader.tsx
+++ b/apps/ceos/src/components/recruit/recruitSubHeader.tsx
@@ -62,7 +62,7 @@ export const RecruitSubHeader = ({
     // new Date(date.startDateDoc.getDate() - 14),
     // 시작 전 이주일 동안 이메일 알림 모집
     date.startDateDoc,
-    new Date(new Date(date.endDateDoc).setHours(24)),
+    date.endDateDoc,
     date.resultDateDoc,
     date.resultDateFinal,
     date.resultDateFinal,

--- a/apps/ceos/src/pages/recruit/apply/index.tsx
+++ b/apps/ceos/src/pages/recruit/apply/index.tsx
@@ -4,7 +4,6 @@ import { useForm } from 'react-hook-form';
 import styled from '@emotion/styled';
 import { RecruitApplyValuesInterface, recruitApi } from '@ceos-fe/utils';
 import {
-  DateProps,
   PartName,
   RecruitApplyFormInterface,
   RecruitApplyResponse,
@@ -29,30 +28,18 @@ const Apply = () => {
     () => recruitApi.GET_RECRUITMENTS(),
   );
 
-  const date = {
-    startDateDoc: dateData ? new Date(dateData.startDateDoc) : '',
-    endDateDoc: dateData ? new Date(dateData.endDateDoc) : '',
-  } as DateProps;
-
-  console.log(date);
-
-  const curDate = new Date();
-
-  function isValid() {
-    return date.startDateDoc <= curDate && curDate <= date.endDateDoc
-      ? true
-      : false;
-  }
-
   // 지원기간 아닐 때 페이지 접근 시 루트로 리다이렉트
   useEffect(() => {
-    const checkValid = async () => {
-      if (!isValid()) {
-        window.location.href = '/'; // 페이지로 리로드
-      }
-    };
-    checkValid();
-  }, []);
+    if (!dateData) return;
+
+    const currentDate = new Date();
+    const startDate = new Date(dateData.startDateDoc);
+    const endDate = new Date(dateData.endDateDoc);
+
+    if (currentDate < startDate || currentDate > endDate) {
+      window.location.href = '/'; // 페이지로 리로드
+    }
+  }, [dateData]);
 
   const [isOpen, setIsOpen] = useState(false);
   const [isSubmit, setIsSubmit] = useState(false);

--- a/apps/ceos/src/pages/recruit/index.tsx
+++ b/apps/ceos/src/pages/recruit/index.tsx
@@ -75,7 +75,7 @@ const Recruit = () => {
 
   const date = {
     startDateDoc: new Date(data ? data.startDateDoc : ''),
-    endDateDoc: new Date(data ? fixVarEndDateDoc : ''),
+    endDateDoc: new Date(data ? data.endDateDoc : ''),
     resultDateDoc: new Date(data ? data.resultDateDoc : ''),
     resultDateFinal: new Date(data ? data.resultDateFinal : ''),
   } as DateProps;


### PR DESCRIPTION
## 🛠 관련 이슈

- 모집 기간임에도 지원 페이지 진입 시 메인 페이지로 즉시 리다이렉트되는 문제
- 모집 페이지와 지원 페이지의 접수 마감 시간 계산 방식이 서로 다른 문제

## 📝 수정 사항

- API 응답이 완료된 후 지원 기간을 검사하도록 수정
- startDateDoc, endDateDoc의 실제 시각을 기준으로 지원 가능 여부 판단
- 모집 페이지와 지원 페이지의 마감 시간 비교 방식 통일
- 불필요한 날짜 변환 및 디버깅 로그 제거