### PR TITLE
Fix: 동적 라우트를 query parameter 기반 정적 페이지로 변경

### DIFF
--- a/apps/admin/src/components/activity/ActivityCardContainer/index.tsx
+++ b/apps/admin/src/components/activity/ActivityCardContainer/index.tsx
@@ -13,7 +13,7 @@ export const ActivityCardContainer = (props: ActivityCardProps) => {
     onSuccess: async () => {
       alert('삭제 완료');
       queryClient.invalidateQueries([['activity']]);
-      router.push('/activity');
+      router.replace('/activity');
     },
   });
 
@@ -22,7 +22,7 @@ export const ActivityCardContainer = (props: ActivityCardProps) => {
   };
 
   const onClickUpdateHandler = (id: number) => {
-    router.push(`/activity/${id}`);
+    router.push({ pathname: '/activity', query: { id } });
   };
 
   return (

--- a/apps/admin/src/components/project/ProjectCardContainer/index.tsx
+++ b/apps/admin/src/components/project/ProjectCardContainer/index.tsx
@@ -21,7 +21,7 @@ export const ProjectCardContainer = (props: ProjectCardProps) => {
   };
 
   const onClickUpdateHandler = (id: number) => {
-    router.push(`/project/edit/${id}`);
+    router.push({ pathname: '/project/edit', query: { id } });
   };
 
   return (

--- a/apps/admin/src/components/reward/RewardCardContainer/index.tsx
+++ b/apps/admin/src/components/reward/RewardCardContainer/index.tsx
@@ -20,7 +20,7 @@ export const RewardCardContainer = (props: RewardCardProps) => {
   };
 
   const onClickUpdateHandler = (generation: number) => {
-    router.push(`/reward/add/${generation}`);
+    router.push({ pathname: '/reward/add', query: { id: generation } });
   };
 
   return (

--- a/apps/admin/src/components/sponsoredBy/SponsoredByContainer/index.tsx
+++ b/apps/admin/src/components/sponsoredBy/SponsoredByContainer/index.tsx
@@ -14,7 +14,7 @@ export const SponsoredByContainer = (props: SponsorCardProps) => {
       onSuccess: async () => {
         alert('삭제 완료');
         queryClient.invalidateQueries([['sponsor']]);
-        router.push('/sponsoredby');
+        router.replace('/sponsoredby');
       },
     },
   );
@@ -24,7 +24,7 @@ export const SponsoredByContainer = (props: SponsorCardProps) => {
   };
 
   const onClickUpdateHandler = (id: number) => {
-    router.push(`/sponsoredby/${id}`);
+    router.push({ pathname: '/sponsoredby', query: { id } });
   };
 
   return (

--- a/apps/admin/src/pages/activity/index.tsx
+++ b/apps/admin/src/pages/activity/index.tsx
@@ -1,11 +1,7 @@
 import React, { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { Flex, Button, Space, TextField, Text } from '@ceos-fe/ui';
-import {
-  RewardResponse,
-  SponsoredByDTO,
-  adminSponsoredByApi,
-} from '@ceos-fe/utils';
+import { RewardResponse, adminActivityApi } from '@ceos-fe/utils';
 import styled from '@emotion/styled';
 import { SponsoredByContainer } from '../../components/sponsoredBy/SponsoredByContainer/index';
 import useInfiniteQueries from '../../hooks/useInfiniteQueries';
@@ -13,52 +9,55 @@ import { PageTitle } from '../../components/Common/PageTitle';
 import { useForm } from 'react-hook-form';
 import { ImageUploader } from '../../components/ImageUploader/index';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { ActivityCardContainer } from '../../components/activity/ActivityCardContainer';
+import {
+  ActivityDTO,
+  ActivityResponse,
+} from '../../../../../packages/utils/src/apis/admin/adminActivityApi';
 
-export default function SponsoredBy() {
+export default function Activity() {
   const queryClient = useQueryClient();
   const router = useRouter();
   const {
     watch,
     register,
     setValue,
-    handleSubmit,
     getValues,
+    handleSubmit,
     formState: { isValid },
   } = useForm();
-  const { infiniteData, ref } = useInfiniteQueries<RewardResponse>({
-    queryKey: ['sponsor'],
+  const { infiniteData, ref } = useInfiniteQueries<ActivityResponse>({
+    queryKey: ['activity'],
     queryFunction: ({ pageParam = 0 }) =>
-      adminSponsoredByApi.GET_SPONSOR({ pageNum: pageParam, limit: 12 }),
-    PageItem: SponsoredByContainer,
+      adminActivityApi.GET_ACTIVITY({ pageNum: pageParam, limit: 12 }),
+    PageItem: ActivityCardContainer,
   });
 
-  // 스폰서 생성 api
-  const postSponsorCreateMutation = useMutation(
-    adminSponsoredByApi.POST_SPONSOR,
+  // 활동 생성 api
+  const postActivityCreateMutation = useMutation(
+    adminActivityApi.POST_ACTIVITY,
     {
       onSuccess: () => {
         alert('추가 완료');
-        queryClient.invalidateQueries([['sponsor']]);
+        queryClient.invalidateQueries([['activity']]);
       },
     },
   );
 
-  // 스폰서 수정 api
-  const patchSponsorCreateMutation = useMutation(
-    adminSponsoredByApi.PAPTCH_SPONSOR,
-    {
-      onSuccess: () => {
-        alert('수정 완료');
-        queryClient.invalidateQueries([['sponsor']]);
-        router.push('/sponsoredby');
-      },
+  // 활동 수정 api
+  const putActivityCreateMutation = useMutation(adminActivityApi.PUT_ACTIVITY, {
+    onSuccess: () => {
+      alert('수정 완료');
+      queryClient.invalidateQueries([['activity']]);
+      router.replace('/activity');
     },
-  );
+  });
 
   // 수정 시 정보 가져오기 api
-  const getSponsorMutation = useMutation(adminSponsoredByApi.GET_ONE_SPONSOR, {
-    onSuccess: async (data: SponsoredByDTO) => {
+  const getActivityMutation = useMutation(adminActivityApi.GET_ONE_ACTIVITY, {
+    onSuccess: async (data: ActivityDTO) => {
       setValue('name', data.name);
+      setValue('content', data.content);
       setValue('imageUrl', data.imageUrl);
     },
     onError: (error: any) => {
@@ -67,15 +66,15 @@ export default function SponsoredBy() {
   });
 
   const onSubmit = (data: any) => {
-    if (Number(router.query[''])) {
-      patchSponsorCreateMutation.mutate({
-        id: Number(Number(router.query[''])),
+    if (Number(router.query.id)) {
+      putActivityCreateMutation.mutate({
+        id: Number(router.query.id),
         payload: {
           ...data,
         },
       });
     } else {
-      postSponsorCreateMutation.mutate({
+      postActivityCreateMutation.mutate({
         payload: {
           ...data,
         },
@@ -84,20 +83,22 @@ export default function SponsoredBy() {
   };
 
   useEffect(() => {
-    if (Number(router.query[''])) {
-      getSponsorMutation.mutate(Number(router.query['']));
+    if (Number(router.query.id)) {
+      getActivityMutation.mutate(Number(router.query.id));
     }
-  }, [router]);
+  }, [router.query.id]);
 
   return (
     <Flex direction="column" align="flex-start" justify="flex-start">
       <Flex align="flex-end" justify="space-between" width={1032}>
         <PageTitle
-          title={'SPONSORED BY'}
-          description={'세오스 후원 단체의 목록을 관리합니다.'}
+          title={'ACTIVITY'}
+          description={'세오스 활동 목록을 관리합니다.'}
         />
       </Flex>
-      <Space height={48} />
+      <div>
+        <Space height={48} />
+      </div>
       <Flex
         direction="row"
         align="flex-start"
@@ -134,10 +135,21 @@ export default function SponsoredBy() {
         </div>
         <div>
           <TextField
-            label="후원 단체명"
+            label="활동 제목"
             placeholder="내용을 입력하세요."
             isAdmin
             {...register('name', {
+              required: true,
+            })}
+          />
+          <Space height={24} />
+          <TextField
+            label="활동 설명"
+            placeholder="내용을 입력하세요."
+            height={64}
+            multiline
+            isAdmin
+            {...register('content', {
               required: true,
             })}
           />
@@ -146,7 +158,7 @@ export default function SponsoredBy() {
             <Text webTypo="Label3">썸네일 이미지</Text>
             <Space height={8} />
             <ImageUploader
-              imageApiType="SPONSOR"
+              imageApiType="ACTIVITY"
               label="imageUrl"
               value={watch('imageUrl')}
               setValue={setValue}

--- a/apps/admin/src/pages/management/add/index.tsx
+++ b/apps/admin/src/pages/management/add/index.tsx
@@ -41,7 +41,7 @@ const UNIVERSITY: Record<string, string> = {
   홍익대학교: 'hongik',
 };
 
-export default function AddManagement() {
+export default function ManagementForm() {
   const router = useRouter();
   const {
     register,

--- a/apps/admin/src/pages/management/index.tsx
+++ b/apps/admin/src/pages/management/index.tsx
@@ -67,7 +67,12 @@ export default function Management() {
             <Button
               variant="admin_stroke"
               webWidth={81}
-              onClick={() => router.push(`/management/add/${record.id}`)}
+              onClick={() =>
+                router.push({
+                  pathname: '/management/add',
+                  query: { id: record.id },
+                })
+              }
             >
               수정하기
             </Button>

--- a/apps/admin/src/pages/project/edit/index.tsx
+++ b/apps/admin/src/pages/project/edit/index.tsx
@@ -17,7 +17,7 @@ const UrlCategoryMap = {
   인스타: 'Instagram',
 };
 
-export default function ProjectDetail() {
+export default function ProjectForm() {
   const router = useRouter();
 
   const postProjectMutation = useMutation(adminProjectApi.POST_PROJECT, {

--- a/apps/admin/src/pages/reward/add/index.tsx
+++ b/apps/admin/src/pages/reward/add/index.tsx
@@ -8,7 +8,7 @@ import { useEffect } from 'react';
 import { Plus } from '@admin/assets/Plus';
 import { css } from '@emotion/react';
 
-export default function AddReward() {
+export default function RewardForm() {
   const router = useRouter();
   const {
     control,

--- a/apps/admin/src/pages/sponsoredby/index.tsx
+++ b/apps/admin/src/pages/sponsoredby/index.tsx
@@ -1,7 +1,11 @@
 import React, { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { Flex, Button, Space, TextField, Text } from '@ceos-fe/ui';
-import { RewardResponse, adminActivityApi } from '@ceos-fe/utils';
+import {
+  RewardResponse,
+  SponsoredByDTO,
+  adminSponsoredByApi,
+} from '@ceos-fe/utils';
 import styled from '@emotion/styled';
 import { SponsoredByContainer } from '../../components/sponsoredBy/SponsoredByContainer/index';
 import useInfiniteQueries from '../../hooks/useInfiniteQueries';
@@ -9,55 +13,52 @@ import { PageTitle } from '../../components/Common/PageTitle';
 import { useForm } from 'react-hook-form';
 import { ImageUploader } from '../../components/ImageUploader/index';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { ActivityCardContainer } from '../../components/activity/ActivityCardContainer/indext';
-import {
-  ActivityDTO,
-  ActivityResponse,
-} from '../../../../../packages/utils/src/apis/admin/adminActivityApi';
 
-export default function Activity() {
+export default function SponsoredBy() {
   const queryClient = useQueryClient();
   const router = useRouter();
   const {
     watch,
     register,
     setValue,
-    getValues,
     handleSubmit,
+    getValues,
     formState: { isValid },
   } = useForm();
-  const { infiniteData, ref } = useInfiniteQueries<ActivityResponse>({
-    queryKey: ['activity'],
+  const { infiniteData, ref } = useInfiniteQueries<RewardResponse>({
+    queryKey: ['sponsor'],
     queryFunction: ({ pageParam = 0 }) =>
-      adminActivityApi.GET_ACTIVITY({ pageNum: pageParam, limit: 12 }),
-    PageItem: ActivityCardContainer,
+      adminSponsoredByApi.GET_SPONSOR({ pageNum: pageParam, limit: 12 }),
+    PageItem: SponsoredByContainer,
   });
 
-  // 활동 생성 api
-  const postActivityCreateMutation = useMutation(
-    adminActivityApi.POST_ACTIVITY,
+  // 스폰서 생성 api
+  const postSponsorCreateMutation = useMutation(
+    adminSponsoredByApi.POST_SPONSOR,
     {
       onSuccess: () => {
         alert('추가 완료');
-        queryClient.invalidateQueries([['activity']]);
+        queryClient.invalidateQueries([['sponsor']]);
       },
     },
   );
 
-  // 활동 수정 api
-  const putActivityCreateMutation = useMutation(adminActivityApi.PUT_ACTIVITY, {
-    onSuccess: () => {
-      alert('수정 완료');
-      queryClient.invalidateQueries([['activity']]);
-      router.push('/activity');
+  // 스폰서 수정 api
+  const patchSponsorCreateMutation = useMutation(
+    adminSponsoredByApi.PAPTCH_SPONSOR,
+    {
+      onSuccess: () => {
+        alert('수정 완료');
+        queryClient.invalidateQueries([['sponsor']]);
+        router.replace('/sponsoredby');
+      },
     },
-  });
+  );
 
   // 수정 시 정보 가져오기 api
-  const getActivityMutation = useMutation(adminActivityApi.GET_ONE_ACTIVITY, {
-    onSuccess: async (data: ActivityDTO) => {
+  const getSponsorMutation = useMutation(adminSponsoredByApi.GET_ONE_SPONSOR, {
+    onSuccess: async (data: SponsoredByDTO) => {
       setValue('name', data.name);
-      setValue('content', data.content);
       setValue('imageUrl', data.imageUrl);
     },
     onError: (error: any) => {
@@ -66,15 +67,15 @@ export default function Activity() {
   });
 
   const onSubmit = (data: any) => {
-    if (Number(router.query[''])) {
-      putActivityCreateMutation.mutate({
-        id: Number(Number(router.query[''])),
+    if (Number(router.query.id)) {
+      patchSponsorCreateMutation.mutate({
+        id: Number(router.query.id),
         payload: {
           ...data,
         },
       });
     } else {
-      postActivityCreateMutation.mutate({
+      postSponsorCreateMutation.mutate({
         payload: {
           ...data,
         },
@@ -83,22 +84,20 @@ export default function Activity() {
   };
 
   useEffect(() => {
-    if (Number(router.query[''])) {
-      getActivityMutation.mutate(Number(router.query['']));
+    if (Number(router.query.id)) {
+      getSponsorMutation.mutate(Number(router.query.id));
     }
-  }, [router]);
+  }, [router.query.id]);
 
   return (
     <Flex direction="column" align="flex-start" justify="flex-start">
       <Flex align="flex-end" justify="space-between" width={1032}>
         <PageTitle
-          title={'ACTIVITY'}
-          description={'세오스 활동 목록을 관리합니다.'}
+          title={'SPONSORED BY'}
+          description={'세오스 후원 단체의 목록을 관리합니다.'}
         />
       </Flex>
-      <div>
-        <Space height={48} />
-      </div>
+      <Space height={48} />
       <Flex
         direction="row"
         align="flex-start"
@@ -135,21 +134,10 @@ export default function Activity() {
         </div>
         <div>
           <TextField
-            label="활동 제목"
+            label="후원 단체명"
             placeholder="내용을 입력하세요."
             isAdmin
             {...register('name', {
-              required: true,
-            })}
-          />
-          <Space height={24} />
-          <TextField
-            label="활동 설명"
-            placeholder="내용을 입력하세요."
-            height={64}
-            multiline
-            isAdmin
-            {...register('content', {
               required: true,
             })}
           />
@@ -158,7 +146,7 @@ export default function Activity() {
             <Text webTypo="Label3">썸네일 이미지</Text>
             <Space height={8} />
             <ImageUploader
-              imageApiType="ACTIVITY"
+              imageApiType="SPONSOR"
               label="imageUrl"
               value={watch('imageUrl')}
               setValue={setValue}


### PR DESCRIPTION
## 🛠 관련 이슈

- 프로젝트는 Yarn PnP를 사용하지만 현재 Netlify의 Next.js Runtime은 **node_modules** 기반 환경을 전제로 하며 **PnP를 공식 지원하지 않습니다**. 

    <img width="662" height="57" alt="스크린샷 2026-08-11 오후 4 06 39" src="https://github.com/user-attachments/assets/9411d2b9-e650-4b59-ac54-c471698d80b9" />

- 클라이언트 라우팅은 브라우저에 이미 내려받은 JavaScript 번들에서 처리되므로 정상 동작했지만, 동적 URL에 직접 접근하거나 새로고침할 때는 Netlify의 Next.js 서버 함수가 요청을 처리하면서 오류가 발생했습니다.

-  Next.js 빌드 산출물과 route manifest에는 해당 동적 페이지가 정상적으로 포함되어 있었습니다. 따라서 페이지가 빌드에서 누락된 문제는 아닌 것으로 확인했습니다.
- 해당 페이지들은 **관리자 페이지로 검색엔진 노출이 필요하지 않고,`getStaticPaths`, SSR, ID별 정적 생성 등 동적 라우트의 이점을 활용**하지 않습니다. ID는 클라이언트 API 요청에만 사용하고 있어 고정 경로와 query parameter 방식으로 단순화했습니다.

## 📝 수정 사항

- 불필요한 optional catch-all 라우트를 일반 정적 페이지로 변경했습니다.
  
  ```text
  /project/edit/123 → /project/edit?id=123
  /management/add/123 → /management/add?id=123
  /reward/add/123 → /reward/add?id=123
  /activity/123 → /activity?id=123
  /sponsoredby/123 → /sponsoredby?id=123
  ```

- 수정 화면 진입 시에는 `router.push()`를 사용하고, 수정 완료 또는 삭제 후 query를 제거할 때는 `router.replace()`를 사용해 불필요한 브라우저 history가 남지 않도록 했습니다.
- `ActivityCardContainer/indext.tsx` 파일명의 오타를 `index.tsx`로 수정했습니다.